### PR TITLE
gracefully stop on TERM signal

### DIFF
--- a/ipinfo.sh
+++ b/ipinfo.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+trap exit TERM
+
 while true; do
     for DATABASE in ${IPINFO_DATABASES}; do
         RESPONSE=$(curl \
@@ -18,5 +20,6 @@ while true; do
         break
     fi
 
-    sleep "$UPDATE_FREQUENCY"
+    sleep "$UPDATE_FREQUENCY" &
+    wait $!
 done


### PR DESCRIPTION
When not being on foreground, a shell script is not leader of its process group and the TERM signal does not kill the commands running as children. This changes ensure the command in the foreground is a shell builtin (wait).