### PR TITLE
use checksum to check if there is a new update

### DIFF
--- a/ipinfo.sh
+++ b/ipinfo.sh
@@ -2,6 +2,15 @@
 
 while true; do
     for DATABASE in ${IPINFO_DATABASES}; do
+        if [ -f ${DATABASE}.mmdb ]; then
+            LOCAL=$(sha256sum ${DATABASE}.mmdb | awk '{print $1}')
+            REMOTE=$(curl --silent https://ipinfo.io/data/free/${DATABASE}.mmdb/checksums?token=${IPINFO_TOKEN} \
+                | sed -n 's/.*"sha256": *"\([a-f0-9]*\)".*/\1/p')
+            if [ "$LOCAL" = "$REMOTE" ]; then
+                echo "${DATABASE}.mmdb is up-to-date."
+                continue
+            fi
+        fi
         RESPONSE=$(curl \
             -s -w '%{http_code}' -L -o "${DATABASE}.mmdb.new" \
             "https://ipinfo.io/data/free/${DATABASE}.mmdb?token=${IPINFO_TOKEN}")


### PR DESCRIPTION
When restarting the Docker container often, it is easy to hit the limit for a given token. Use the checksum API endpoint to check if we have an update available.

The parsing is a bit crude to avoid pulling jq. The error handling does not need to be very robust as if the compute the wrong checksum, it won't match the local one and we will trigger a download.