### PR TITLE
Add support for DBs that do not exist on the `data/free` endpoint

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,22 +1,14 @@
 name: Docker
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   push:
-    branches: [ "master" ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*', 'latest' ]
-  pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
+    tags: ['v*.*.*', 'latest']
 
 env:
-  # Use docker.io for Docker Hub if empty
+  # Use ghcr.io for GitHub Container Registry
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
+  # GitHub repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
 
@@ -27,70 +19,55 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
+      # Install the cosign for signing images
       - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        uses: sigstore/cosign-installer@v3.5.0
         with:
           cosign-release: 'v2.2.4'
 
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
+      # Set up Docker Buildx for multi-platform builds
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@v3.0.0
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
+      # Log in to GitHub Container Registry
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
+      # Extract metadata for Docker image
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=latest
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
+      # Build and push Docker image for all architectures
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@v5.0.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
+      # Sign the resulting Docker image digest except on PRs
       - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
         env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
-            type=latest
+            type=raw,value=latest
 
       # Build and push Docker image for all architectures
       - name: Build and push Docker image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,7 +51,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest
 
       # Build and push Docker image for all architectures
       - name: Build and push Docker image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,96 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*', 'latest' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.gz
+*.csv
+*.json
+*.parquet
+*.mmdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /data
 ENV UPDATE_FREQUENCY=0
 ENV IPINFO_TOKEN='my_ipinfo_token'
 ENV IPINFO_DATABASES='ipinfo_lite'
+ENV DEFAULT_DB_FORMAT='mmdb'
 
 # copy the script
 COPY ipinfo.sh /usr/local/bin/ipinfo.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ WORKDIR /data
 # set environment variable
 ENV UPDATE_FREQUENCY=0
 ENV IPINFO_TOKEN='my_ipinfo_token'
-ENV IPINFO_DATABASES='ipinfo_lite'
+ENV IPINFO_DATABASES='country_asn.mmdb'
 ENV DEFAULT_DB_FORMAT='mmdb'
+ENV AUTO_EXTRACT_GZ='false'
 
 # copy the script
 COPY ipinfo.sh /usr/local/bin/ipinfo.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,8 @@ WORKDIR /data
 # set environment variable
 ENV UPDATE_FREQUENCY=0
 ENV IPINFO_TOKEN='my_ipinfo_token'
-ENV IPINFO_DATABASES='country_asn.mmdb'
+ENV IPINFO_DATABASES='ipinfo_lite'
 ENV DEFAULT_DB_FORMAT='mmdb'
-ENV AUTO_EXTRACT_GZ='false'
 
 # copy the script
 COPY ipinfo.sh /usr/local/bin/ipinfo.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /data
 # set environment variable
 ENV UPDATE_FREQUENCY=0
 ENV IPINFO_TOKEN='my_ipinfo_token'
-ENV IPINFO_DATABASES='country_asn'
+ENV IPINFO_DATABASES='ipinfo_lite'
 
 # copy the script
 COPY ipinfo.sh /usr/local/bin/ipinfo.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,17 @@ RUN apk add --no-cache curl
 
 WORKDIR /data
 
-# set environment variable.
+# set environment variable
 ENV UPDATE_FREQUENCY=0
-ENV IPINFO_TOKEN='98266fdad56289'
+ENV IPINFO_TOKEN='my_ipinfo_token'
 ENV IPINFO_DATABASES='country_asn'
 
-# copy the script.
+# copy the script
 COPY ipinfo.sh /usr/local/bin/ipinfo.sh
 RUN chmod +x /usr/local/bin/ipinfo.sh
 
 # create the volume.
 VOLUME /data
 
-# run the script.
+# run the script
 CMD ["/usr/local/bin/ipinfo.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [<img src="https://ipinfo.io/static/ipinfo-small.svg" alt="IPinfo" width="24"/>](https://ipinfo.io/) IPinfo Docker Image
 
-`ipinfo-db` is a docker image by [IPinfo.io](https://ipinfo.io) that downloads free country asn database in mmdb format.
+`ipinfo-db` is a docker image by [IPinfo.io](https://ipinfo.io) that downloads IPInfo databases (for info on what DBs are available, see [here](https://ipinfo.io/developers/database-filename-reference)).
 
 ## Pull image
 ```bash
@@ -9,8 +9,8 @@ docker pull ipinfo/ipinfo-db:latest
 
 ## Configuration
 
-- `IPINFO_TOKEN` (optional) - Set you ipinfo token.
-- `IPINFO_DATABASES` (optional) - Databases to download, default to `country_asn`.
+- `IPINFO_TOKEN` (required) - Set you IPInfo token available in your [dashboard](https://ipinfo.io/dashboard/token)
+- `IPINFO_DATABASES` (optional) - Space-separated list of databases to download. Defaults to `ipinfo_lite`.
 - `UPDATE_FREQUENCY` (optional) - Interval of updating database in bash sleep format. If this is not set or is set to 0 (default), image will run once and exit.
 
 ## Usage:
@@ -19,7 +19,7 @@ docker pull ipinfo/ipinfo-db:latest
 docker run -v <dir>:/data  \
   -e IPINFO_TOKEN=<ipinfo_token> \
   -e UPDATE_FREQUENCY=<update_frequency> \
-  ipinfo-db
+  ipinfo/ipinfo-db
 ```
 
 `<dir>` local directory that you want to download the databases to.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ docker pull ipinfo/ipinfo-db:latest
 
 ## Configuration
 
-- `IPINFO_TOKEN` (required) - Set you IPInfo token available in your [dashboard](https://ipinfo.io/dashboard/token)
+- `IPINFO_TOKEN` (required) - Set you IPInfo token available in your [dashboard](https://ipinfo.io/dashboard/token).
 - `IPINFO_DATABASES` (optional) - Space-separated list of databases to download. Defaults to `ipinfo_lite`.
-- `UPDATE_FREQUENCY` (optional) - Interval of updating database in bash sleep format. If this is not set or is set to 0 (default), image will run once and exit.
+- `UPDATE_FREQUENCY` (optional) - Interval of updating database in bash sleep format. If this is not set or is set to `0` (default), image will run once and exit.
+- `DEFAULT_DB_FORMAT` (optional) - Default database format. Can be `mmdb`, `csv`, `json` or `parquet`. Defaults to `mmdb`.
 
 ## Usage:
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ docker pull ipinfo/ipinfo-db:latest
 ## Configuration
 
 - `IPINFO_TOKEN` (required) - Set you IPInfo token available in your [dashboard](https://ipinfo.io/dashboard/token).
-- `IPINFO_DATABASES` (optional) - Space-separated list of databases to download. Defaults to `ipinfo_lite`.
+- `IPINFO_DATABASES` (optional) - Space-separated list of databases to download. **Notes**:  
+**(1)** The default value is set to `country_asn.mmdb` to ensure backwards compatibility with the previous version of the image, but we recommend using the newer `ipinfo_lite` database instead. The data provided by `ipinfo_lite` is the same as `country_asn`, but the schema has changed. See [here](https://github.com/ipinfo/docker/issues/9#issuecomment-2868624800) for more details.
 - `UPDATE_FREQUENCY` (optional) - Interval of updating database in bash sleep format. If this is not set or is set to `0` (default), image will run once and exit.
 - `DEFAULT_DB_FORMAT` (optional) - Default database format. Can be `mmdb`, `csv`, `json` or `parquet`. Defaults to `mmdb`.
+- `AUTO_EXTRACT_GZ` (optional) - If set to `true` or `1`, the downloaded files will be extracted from gzipped format. Defaults to `false`. **Notes**:  
+**(1)** This increases the storage requirements of downloaded files, as both th `.gz` file, and the extracted file will be stored in the same directory - this is to check the hash of the file on disk against the hash of the file on IPinfo's servers (and prevent re-downloading the same file).  
+**(2)** This variable is only relevant for `.csv` and `.json` files, as the `.mmdb` and `.parquet` files are not gzipped on IPinfo's servers.
 
 ## Usage:
 

--- a/ipinfo.sh
+++ b/ipinfo.sh
@@ -80,6 +80,22 @@ while true; do
         else
             echo "${DATABASE} database downloaded in /data volume."
             mv "${DATABASE}.new" "${DATABASE}"
+
+            # Check if automated extraction of GZ files is enabled
+            if [ "$AUTO_EXTRACT_GZ" = "1" ] || [ "$AUTO_EXTRACT_GZ" = "true" ]; then
+                # Check if the file is a GZ file
+                if [[ "${DATABASE}" == *.gz ]]; then
+                    # Extract the GZIP file (while keeping the original)
+                    gunzip -k "${DATABASE}"
+
+                    # Check if the extraction was successful
+                    if [ $? -eq 0 ]; then
+                        echo "Extracted ${DATABASE} to ${DATABASE%.gz}"
+                    else
+                        echo "Failed to extract ${DATABASE}"
+                    fi
+                fi
+            fi
         fi
     done
     

--- a/ipinfo.sh
+++ b/ipinfo.sh
@@ -1,10 +1,23 @@
 #!/bin/sh
 
+get_root_url() {
+    case "$1" in
+        "country_asn" | "country" | "asn")
+            echo "https://ipinfo.io/data/free/"
+            ;;
+        *)
+            echo "https://ipinfo.io/data/"
+            ;;
+    esac
+}
+
 while true; do
     for DATABASE in ${IPINFO_DATABASES}; do
+        BASE_URL=$(get_root_url "$DATABASE")
+        DB_URL="${BASE_URL}${DATABASE}.mmdb"
         if [ -f ${DATABASE}.mmdb ]; then
             LOCAL=$(sha256sum ${DATABASE}.mmdb | awk '{print $1}')
-            REMOTE=$(curl --silent https://ipinfo.io/data/free/${DATABASE}.mmdb/checksums?token=${IPINFO_TOKEN} \
+            REMOTE=$(curl --silent ${DB_URL}/checksums?token=${IPINFO_TOKEN} \
                 | sed -n 's/.*"sha256": *"\([a-f0-9]*\)".*/\1/p')
             if [ "$LOCAL" = "$REMOTE" ]; then
                 echo "${DATABASE}.mmdb is up-to-date."
@@ -13,7 +26,7 @@ while true; do
         fi
         RESPONSE=$(curl \
             -s -w '%{http_code}' -L -o "${DATABASE}.mmdb.new" \
-            "https://ipinfo.io/data/free/${DATABASE}.mmdb?token=${IPINFO_TOKEN}")
+            "${DB_URL}?token=${IPINFO_TOKEN}")
         if [ "$RESPONSE" != "200" ]; then
             echo "$RESPONSE Failed to download ${DATABASE}.mmdb database."
             rm "${DATABASE}.mmdb.new" 2> /dev/null
@@ -23,7 +36,7 @@ while true; do
         fi
     done
     
-    if [ $UPDATE_FREQUENCY == 0 ]; then
+    if [ "$UPDATE_FREQUENCY" = "0" ]; then
         break
     fi
 

--- a/ipinfo.sh
+++ b/ipinfo.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 
 get_root_url() {
-    case "$1" in
+    # Extract the base name without the file extension
+    BASE_NAME="${1%%.*}"
+
+    case "$BASE_NAME" in
         "country_asn" | "country" | "asn")
             echo "https://ipinfo.io/data/free/"
             ;;
@@ -11,33 +14,79 @@ get_root_url() {
     esac
 }
 
+get_file_extension() {
+    case "$1" in
+        "mmdb")
+            echo ".mmdb"
+            ;;
+        "csv")
+            echo ".csv.gz"
+            ;;
+        "json")
+            echo ".json.gz"
+            ;;
+        "parquet")
+            echo ".parquet"
+            ;;
+    esac
+}
+
 while true; do
+    # Check if DEFAULT_DB_FORMAT is set and valid
+    if ! [[ "$DEFAULT_DB_FORMAT" =~ ^(mmdb|csv|json|parquet)$ ]]; then
+        echo "Error: DEFAULT_DB_FORMAT is either not set, or is not allowed. Please set it to either 'mmdb', 'csv', 'json', or 'parquet'. Value received: '$DEFAULT_DB_FORMAT'"
+        break
+    fi
+
+    # Iterate over the databases
     for DATABASE in ${IPINFO_DATABASES}; do
+        # Check if DATABASE already has a file extension
+        if [[ "$DATABASE" != *.* ]]; then
+            # Append the correct file extension based on DEFAULT_DB_FORMAT
+            FILE_EXTENSION=$(get_file_extension "$DEFAULT_DB_FORMAT")
+            DATABASE="${DATABASE}${FILE_EXTENSION}"
+        fi
+
+        # Retrieve the correct root URL based on the database name
         BASE_URL=$(get_root_url "$DATABASE")
-        DB_URL="${BASE_URL}${DATABASE}.mmdb"
-        if [ -f ${DATABASE}.mmdb ]; then
-            LOCAL=$(sha256sum ${DATABASE}.mmdb | awk '{print $1}')
+        DB_URL="${BASE_URL}${DATABASE}"
+
+        if [ -f "${DATABASE}" ]; then
+            LOCAL=$(sha256sum "${DATABASE}" | awk '{print $1}')
             REMOTE=$(curl --silent ${DB_URL}/checksums?token=${IPINFO_TOKEN} \
                 | sed -n 's/.*"sha256": *"\([a-f0-9]*\)".*/\1/p')
+            # Check if the local and remote checksums are the same
+            # If they are, skip the download
             if [ "$LOCAL" = "$REMOTE" ]; then
-                echo "${DATABASE}.mmdb is up-to-date."
+                echo "${DATABASE} is up to date."
                 continue
             fi
         fi
+
+        # Download the database
         RESPONSE=$(curl \
-            -s -w '%{http_code}' -L -o "${DATABASE}.mmdb.new" \
+            -s -w '%{http_code}' -L -o "${DATABASE}.new" \
             "${DB_URL}?token=${IPINFO_TOKEN}")
         if [ "$RESPONSE" != "200" ]; then
-            echo "$RESPONSE Failed to download ${DATABASE}.mmdb database."
-            rm "${DATABASE}.mmdb.new" 2> /dev/null
+            # Check if response code is 429
+            if [ "$RESPONSE" = "429" ]; then
+                echo "Rate limit exceeded. Please try again later."
+                break
+            else 
+                echo "$RESPONSE Failed to download ${DATABASE} database from '${DB_URL}'."
+                break
+            fi
+            rm "${DATABASE}.new" 2> /dev/null
         else
-            echo "${DATABASE}.mmdb database downloaded in /data volume."
-            mv "${DATABASE}.mmdb.new" "${DATABASE}.mmdb"
+            echo "${DATABASE} database downloaded in /data volume."
+            mv "${DATABASE}.new" "${DATABASE}"
         fi
     done
     
     if [ "$UPDATE_FREQUENCY" = "0" ]; then
         break
+    else
+        echo "Sleeping for $UPDATE_FREQUENCY seconds before the next update."
     fi
 
     sleep "$UPDATE_FREQUENCY"


### PR DESCRIPTION
These changes resolve #9, and at the same time add support for downloading any of the IPInfo MMDBs that do not exist on the `data/free` endpoint.

The `https://ipinfo.io/data/free/` root URL gets used in requests for the `country_asn`, `country`, or `asn` databases. Otherwise, the script defaults to `https://ipinfo.io/data/`. More endpoints can be defined in the `ipinfo.sh` file (`get_root_url()`).